### PR TITLE
capslock: Use proper registry key on Windows 7 and higher

### DIFF
--- a/README.org
+++ b/README.org
@@ -94,12 +94,12 @@ On Windows you can use a simple registry file to tweak the CapsLock mapping.  Sa
 #+begin_src
 
 REGEDIT4
-[HKEY_CURRENT_USER\Keyboard Layout]
+[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Keyboard Layout]
 "Scancode Map"=hex:00,00,00,00,00,00,00,00,02,00,00,00,1d,00,3a,00,00,00,00,00
 
 #+end_src
 
-Now double-click on this file in Windows Explorer and allow Windows to apply it to your registry settings.  After you log out of your current session and log back in the new key mapping should be in effect.
+Now double-click on this file in Windows Explorer and allow Windows to apply it to your registry settings.  After you log out of your current session and log back in the new key mapping should be in effect. Note that this change will affect *all* users on your system.
 
 *macOS*
 


### PR DESCRIPTION
Unfortunately, the registry key in the current README doesn't work on Windows 7 or higher. One has to change the key in the [`HKEY_LOCAL_MACHINE` hierarchy][1], which affects all users.

That being said, thanks for the recommendation to change the capslock into a control key. I'm still getting used to it, but it already feels better than the old way.

 [1]: https://docs.microsoft.com/de-de/windows-hardware/drivers/hid/keyboard-and-mouse-class-drivers#scan-code-mapper-for-keyboards