### PR TITLE
Make line numbers fixed pitch in org-mode

### DIFF
--- a/Emacs.org
+++ b/Emacs.org
@@ -356,7 +356,9 @@ The =efs/org-font-setup= function configures various text faces to tweak the siz
     (set-face-attribute 'org-verbatim nil :inherit '(shadow fixed-pitch))
     (set-face-attribute 'org-special-keyword nil :inherit '(font-lock-comment-face fixed-pitch))
     (set-face-attribute 'org-meta-line nil :inherit '(font-lock-comment-face fixed-pitch))
-    (set-face-attribute 'org-checkbox nil  :inherit 'fixed-pitch))
+    (set-face-attribute 'org-checkbox nil  :inherit 'fixed-pitch)
+    (set-face-attribute 'line-number nil :inherit 'fixed-pitch)
+    (set-face-attribute 'line-number-current-line nil :inherit 'fixed-pitch))
 
 #+end_src
 


### PR DESCRIPTION
This resolves an issue when using display-line-numbers in Org Mode buffers where line numbers are not fixed pitch, causing alignment problems from line numbers with varying widths.