### PR TITLE
Fix "Symbol’s function definition is void"

### DIFF
--- a/Emacs.org
+++ b/Emacs.org
@@ -1087,6 +1087,7 @@ Dired is a built-in file manager for Emacs that does some pretty amazing things!
 
   (use-package dired
     :ensure nil
+    :after evil-collection
     :commands (dired dired-jump)
     :bind (("C-x C-j" . dired-jump))
     :custom ((dired-listing-switches "-agho --group-directories-first"))

--- a/init.el
+++ b/init.el
@@ -580,6 +580,7 @@
 
 (use-package dired
   :ensure nil
+  :after evil-collection
   :commands (dired dired-jump)
   :bind (("C-x C-j" . dired-jump))
   :custom ((dired-listing-switches "-agho --group-directories-first"))


### PR DESCRIPTION
#43 