### PR TITLE
Changing mu syntax to match new one

### DIFF
--- a/show-notes/Emacs-Mail-01.org
+++ b/show-notes/Emacs-Mail-01.org
@@ -129,7 +129,8 @@ Run the initial index, providing your e-mail address so it knows how to identify
 
 #+begin_src sh
 
-  mu index --maildir=~/Mail --my-address=systemcrafters.test@gmail.com
+  mu init --maildir=~/Mail --my-address=systemcrafters.test@gmail.com
+  mu index
 
 #+end_src
 


### PR DESCRIPTION
Ubuntu 20.04 has an older version of mu and so doesnt have the new syntax change.
Using the old command in a version of that is mu 1.3.8 or higher will give error like this.
```
NOTE: as of mu 1.3.8, 'mu index' no longer uses the
--maildir/-m or --my-address options.

Instead, these options should be passed to 'mu init'.
See the mu-init(1) or the mu4e reference manual,
'Initializing the message store' for details.

```
